### PR TITLE
Fix the Ballerina.toml updating before the Ballerina push

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -22,4 +22,4 @@ jobs:
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                     GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
-                    ./gradlew ballerinaPublish
+                    ./gradlew clean build -PpublishToCentral=true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ Execute the commands below to build from source.
 
         ./gradlew clean build -Pdebug=<port>
 
+1. Publish ZIP artifact to the local `.m2` repository:
+
+        ./gradlew clean build publishToMavenLocal
+
+1. Publish the generated artifacts to the local Ballerina central repository:
+   
+        ./gradlew clean build -PpublishToLocalCentral=true
+
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Execute the commands below to build from source.
 1. Publish the generated artifacts to the local Ballerina central repository:
    
         ./gradlew clean build -PpublishToLocalCentral=true
+1. Publish the generated artifacts to the Ballerina central repository:
 
+        ./gradlew clean build -PpublishToCentral=true
+
+   
 ## Contributing to Ballerina
 
 As an open source project, Ballerina welcomes contributions from the community. 

--- a/jballerina.java.arrays-ballerina/build.gradle
+++ b/jballerina.java.arrays-ballerina/build.gradle
@@ -118,6 +118,9 @@ task initializeVariables {
     if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
         needPublishToLocalCentral = true
     }
+    if (project.hasProperty("publishToCentral") && (project.findProperty("publishToCentral") == "true")) {
+        needPublishToCentral = true
+    }
 
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||

--- a/jballerina.java.arrays-ballerina/build.gradle
+++ b/jballerina.java.arrays-ballerina/build.gradle
@@ -77,7 +77,7 @@ task unpackJballerinaTools(type: Copy) {
     }
 }
 
-task updateTomlVersions {
+task updateTomlFile {
     doLast {
         def newConfig = ballerinaConfigFile.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
@@ -100,6 +100,7 @@ def testParams = ""
 def needSeparateTest = false
 def needBuildWithTest = false
 def needPublishToCentral = false
+def needPublishToLocalCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -114,22 +115,18 @@ task initializeVariables {
     if (project.hasProperty("balJavaDebug")) {
         balJavaDebugParam = "BAL_JAVA_DEBUG=${project.findProperty("balJavaDebug")}"
     }
+    if (project.hasProperty("publishToLocalCentral") && (project.findProperty("publishToLocalCentral") == "true")) {
+        needPublishToLocalCentral = true
+    }
 
     gradle.taskGraph.whenReady { graph ->
-        if (graph.hasTask(":${packageName}-ballerina:build") ||
-                graph.hasTask(":${packageName}-ballerina:publish") ||
+        if (graph.hasTask(":${packageName}-ballerina:build") || graph.hasTask(":${packageName}-ballerina:publish") ||
                 graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-            needSeparateTest = false
 
-            if (graph.hasTask(":${packageName}-ballerina:build")) {
-                needBuildWithTest = true
-            }
+            needSeparateTest = false
+            needBuildWithTest = true
             if (graph.hasTask(":${packageName}-ballerina:publish")) {
-                needBuildWithTest = true
                 needPublishToCentral = true
-            }
-            if (graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
-                needBuildWithTest = true
             }
         } else {
             needSeparateTest = true
@@ -143,8 +140,8 @@ task initializeVariables {
     }
 }
 
-
 task ballerinaBuild {
+    inputs.dir file(project.projectDir)
 
     doLast {
         if (needSeparateTest) {
@@ -157,9 +154,7 @@ task ballerinaBuild {
                     commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test ${testParams} ${groupParams} ${disableGroups} ${debugParams}"
                 }
             }
-        }
-
-        if (needBuildWithTest) {
+        } else if (needBuildWithTest) {
             exec {
                 workingDir project.projectDir
                 environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
@@ -218,6 +213,17 @@ task ballerinaBuild {
             } else {
                 throw new InvalidUserDataException("Central Access Token is not present")
             }
+        } else if (needPublishToLocalCentral) {
+            println("Publishing to the ballerina local central repository..")
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%% --repository=local"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal push --repository=local"
+                }
+            }
         }
     }
 
@@ -225,7 +231,6 @@ task ballerinaBuild {
     outputs.dir artifactBallerinaDocs
     outputs.dir artifactLibParent
 }
-
 
 task createArtifactZip(type: Zip) {
     destinationDirectory = file("$buildDir/distributions")
@@ -251,9 +256,8 @@ publishing {
     }
 }
 
-updateTomlVersions.dependsOn unpackJballerinaTools
-
-ballerinaBuild.dependsOn updateTomlVersions
+updateTomlFile.dependsOn unpackJballerinaTools
+ballerinaBuild.dependsOn updateTomlFile
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn ":${packageName}-test-utils:build"
 ballerinaBuild.finalizedBy revertTomlFile
@@ -261,4 +265,3 @@ test.dependsOn ballerinaBuild
 build.dependsOn ballerinaBuild
 publishToMavenLocal.dependsOn build
 publish.dependsOn build
-

--- a/jballerina.java.arrays-ballerina/build.gradle
+++ b/jballerina.java.arrays-ballerina/build.gradle
@@ -118,7 +118,7 @@ task initializeVariables {
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina:build") ||
                 graph.hasTask(":${packageName}-ballerina:publish") ||
-                graph.hasTask(":${packageName}-ballerina:publishToMavenLocal"))  {
+                graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
             needSeparateTest = false
 
             if (graph.hasTask(":${packageName}-ballerina:build")) {
@@ -200,24 +200,24 @@ task ballerinaBuild {
         }
 
         if (needPublishToCentral) {
-        if (project.version.endsWith('-SNAPSHOT') ||
-                project.version.matches(project.ext.timestampedVersionRegex)) {
-            return
-        }
-        if (ballerinaCentralAccessToken != null) {
-            println("Publishing to the ballerina central..")
-            exec {
-                workingDir project.projectDir
-                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
-                } else {
-                    commandLine 'sh', '-c', "$distributionBinPath/bal push"
-                }
+            if (project.version.endsWith('-SNAPSHOT') ||
+                    project.version.matches(project.ext.timestampedVersionRegex)) {
+                return
             }
-        } else {
-            throw new InvalidUserDataException("Central Access Token is not present")
-        }
+            if (ballerinaCentralAccessToken != null) {
+                println("Publishing to the ballerina central..")
+                exec {
+                    workingDir project.projectDir
+                    environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        commandLine 'cmd', '/c', "$distributionBinPath/bal.bat push && exit %%ERRORLEVEL%%"
+                    } else {
+                        commandLine 'sh', '-c', "$distributionBinPath/bal push"
+                    }
+                }
+            } else {
+                throw new InvalidUserDataException("Central Access Token is not present")
+            }
         }
     }
 

--- a/jballerina.java.arrays-ballerina/build.gradle
+++ b/jballerina.java.arrays-ballerina/build.gradle
@@ -97,6 +97,9 @@ def disableGroups = ""
 def debugParams = ""
 def balJavaDebugParam = ""
 def testParams = ""
+def needSeparateTest = false
+def needBuildWithTest = false
+def needPublishToCentral = false
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -116,9 +119,20 @@ task initializeVariables {
         if (graph.hasTask(":${packageName}-ballerina:build") ||
                 graph.hasTask(":${packageName}-ballerina:publish") ||
                 graph.hasTask(":${packageName}-ballerina:publishToMavenLocal"))  {
-            ballerinaTest.enabled = false
+            needSeparateTest = false
+
+            if (graph.hasTask(":${packageName}-ballerina:build")) {
+                needBuildWithTest = true
+            }
+            if (graph.hasTask(":${packageName}-ballerina:publish")) {
+                needBuildWithTest = true
+                needPublishToCentral = true
+            }
+            if (graph.hasTask(":${packageName}-ballerina:publishToMavenLocal")) {
+                needBuildWithTest = true
+            }
         } else {
-            ballerinaTest.enabled = true
+            needSeparateTest = true
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
@@ -126,81 +140,66 @@ task initializeVariables {
         } else {
             testParams = "--skip-tests"
         }
-
-        if (graph.hasTask(":${packageName}-ballerina:publish")) {
-            ballerinaPublish.enabled = true
-        } else {
-            ballerinaPublish.enabled = false
-        }
     }
 }
 
-task ballerinaTest {
-    doLast {
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test --code-coverage --includes=* ${groupParams} ${disableGroups} ${debugParams}"
-            }
-        }
-    }
-}
 
 task ballerinaBuild {
-    inputs.dir file(project.projectDir)
 
     doLast {
-        // Build and populate caches
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build -c ${testParams} ${debugParams}"
+        if (needSeparateTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat test ${testParams} ${groupParams} ${disableGroups} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal test ${testParams} ${groupParams} ${disableGroups} ${debugParams}"
+                }
             }
         }
-        // extract bala file to artifact cache directory
-        file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+
+        if (needBuildWithTest) {
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$balJavaDebugParam $distributionBinPath/bal.bat build -c ${testParams} ${debugParams} && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$balJavaDebugParam $distributionBinPath/bal build -c ${testParams} ${debugParams}"
+                }
+            }
+            // extract bala file to artifact cache directory
+            file("$project.projectDir/target/bala").eachFileMatch(~/.*.bala/) { balaFile ->
+                copy {
+                    from zipTree(balaFile)
+                    into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                }
+            }
             copy {
-                from zipTree(balaFile)
-                into file("$artifactCacheParent/bala/${packageOrg}/${packageName}/${tomlVersion}/${platform}")
+                from file("$project.projectDir/target/cache")
+                exclude '**/*-testable.jar'
+                exclude '**/tests_cache/'
+                into file("$artifactCacheParent/cache/")
+            }
+
+            // Doc creation and packing
+            exec {
+                workingDir project.projectDir
+                environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                    commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
+                } else {
+                    commandLine 'sh', '-c', "$distributionBinPath/bal doc"
+                }
+            }
+            copy {
+                from file("$project.projectDir/target/apidocs/${packageName}")
+                into file("$project.projectDir/build/docs_parent/docs/${packageName}")
             }
         }
-        copy {
-            from file("$project.projectDir/target/cache")
-            exclude '**/*-testable.jar'
-            exclude '**/tests_cache/'
-            into file("$artifactCacheParent/cache/")
-        }
 
-        // Doc creation and packing
-        exec {
-            workingDir project.projectDir
-            environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/bal.bat doc && exit %%ERRORLEVEL%%"
-            } else {
-                commandLine 'sh', '-c', "$distributionBinPath/bal doc"
-            }
-        }
-        copy {
-            from file("$project.projectDir/target/apidocs/${packageName}")
-            into file("$project.projectDir/build/docs_parent/docs/${packageName}")
-        }
-        ballerinaConfigFile.text = originalConfig
-    }
-
-    outputs.dir artifactCacheParent
-    outputs.dir artifactBallerinaDocs
-    outputs.dir artifactLibParent
-}
-
-task ballerinaPublish {
-    doLast {
+        if (needPublishToCentral) {
         if (project.version.endsWith('-SNAPSHOT') ||
                 project.version.matches(project.ext.timestampedVersionRegex)) {
             return
@@ -219,8 +218,14 @@ task ballerinaPublish {
         } else {
             throw new InvalidUserDataException("Central Access Token is not present")
         }
+        }
     }
+
+    outputs.dir artifactCacheParent
+    outputs.dir artifactBallerinaDocs
+    outputs.dir artifactLibParent
 }
+
 
 task createArtifactZip(type: Zip) {
     destinationDirectory = file("$buildDir/distributions")
@@ -248,22 +253,12 @@ publishing {
 
 updateTomlVersions.dependsOn unpackJballerinaTools
 
-ballerinaTest.dependsOn updateTomlVersions
-ballerinaTest.dependsOn initializeVariables
-ballerinaTest.dependsOn ":${packageName}-test-utils:build"
-ballerinaTest.finalizedBy revertTomlFile
-test.dependsOn ballerinaTest
-
-ballerinaBuild.dependsOn test
 ballerinaBuild.dependsOn updateTomlVersions
 ballerinaBuild.dependsOn initializeVariables
 ballerinaBuild.dependsOn ":${packageName}-test-utils:build"
 ballerinaBuild.finalizedBy revertTomlFile
+test.dependsOn ballerinaBuild
 build.dependsOn ballerinaBuild
+publishToMavenLocal.dependsOn build
+publish.dependsOn build
 
-ballerinaPublish.dependsOn ballerinaBuild
-ballerinaPublish.dependsOn updateTomlVersions
-ballerinaPublish.dependsOn initializeVariables
-ballerinaPublish.dependsOn ":${packageName}-test-utils:build"
-ballerinaPublish.finalizedBy revertTomlFile
-publish.dependsOn ballerinaPublish


### PR DESCRIPTION
## Purpose
Incorporate all tests, build, and push into one task.
Then, we don't need to repetitively run update TOML and revert TOML tasks; running those two once will be enough.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/1247

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
