### PR TITLE
Set flag to enable Jacoco Coverage XML generation

### DIFF
--- a/jballerina.java.arrays-ballerina/build.gradle
+++ b/jballerina.java.arrays-ballerina/build.gradle
@@ -136,7 +136,7 @@ task initializeVariables {
         }
 
         if (graph.hasTask(":${packageName}-ballerina:test")) {
-            testParams = "--code-coverage --includes=*"
+            testParams = "--code-coverage --jacoco-xml --includes=*"
         } else {
             testParams = "--skip-tests"
         }


### PR DESCRIPTION
Set flag to enable Jacoco Coverage XML generation. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/30381